### PR TITLE
gc+regions needs to be at trace, not debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Build as any Maven-driven Java project:
 #### Saving JVM session
 Add this additional flag to an active JVM running Shenandoah:
 
-    $ -Xlog:gc+region=debug:<file name>::filesize=<Target byte size for log rotation>,filecount=<Number of files to keep in rotation>
+    $ -Xlog:gc+region=trace:<file name>::filesize=<Target byte size for log rotation>,filecount=<Number of files to keep in rotation>
 
 
 #### Replaying JVM session
@@ -71,3 +71,4 @@ Add this additional flag to an active JVM running Shenandoah:
 Sample region popup window view
 
 <img src="images/sample-region-popup-screenshot.png" width="150">
+


### PR DESCRIPTION
Readme instructions have incorrect log level

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace

### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/shenandoah-visualizer.git pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/shenandoah-visualizer.git pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/shenandoah-visualizer/pull/2.diff">https://git.openjdk.org/shenandoah-visualizer/pull/2.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/shenandoah-visualizer/pull/2#issuecomment-3025579219)
</details>
